### PR TITLE
Make links optional

### DIFF
--- a/lib/jsonapi_plug/api.ex
+++ b/lib/jsonapi_plug/api.ex
@@ -42,6 +42,11 @@ defmodule JSONAPIPlug.API do
       type: :boolean,
       default: false
     ],
+    links: [
+      doc: "Enable link generation.",
+      type: :boolean,
+      default: true
+    ],
     host: [
       doc: "Hostname used for link generation instead of deriving it from the connection.",
       type: :string


### PR DESCRIPTION
Using `Benchee` I run this

```
  test "bench" do
    conn =
      conn(:get, "/posts?include=author")
      |> Conn.assign(:data, [@default_data])
      |> Conn.assign(:meta, %{total_pages: 1})

    Benchee.run(%{"call" => fn -> MyPostPlug.call(conn, []) end}, time: 10, memory_time: 2)
  end
```

With links 
```
Name           ips        average  deviation         median         99th %
call        7.53 K      132.73 μs    ±18.14%      122.57 μs      212.69 μs

Memory usage statistics:

Name    Memory usage
call        51.63 KB
```

Without links:
```
Name           ips        average  deviation         median         99th %
call       10.42 K       95.93 μs    ±18.39%       89.55 μs      164.67 μs

Memory usage statistics:

Name    Memory usage
call        42.19 KB
```

