### PR TITLE
Allow restricting includes

### DIFF
--- a/lib/jsonapi_plug.ex
+++ b/lib/jsonapi_plug.ex
@@ -13,6 +13,7 @@ defmodule JSONAPIPlug do
   @type case :: :camelize | :dasherize | :underscore
 
   @type t :: %__MODULE__{
+          allowed_includes: keyword(keyword()),
           api: API.t(),
           fields: term(),
           filter: term(),
@@ -22,7 +23,8 @@ defmodule JSONAPIPlug do
           resource: Resource.t(),
           sort: term()
         }
-  defstruct api: nil,
+  defstruct allowed_includes: nil,
+            api: nil,
             fields: nil,
             filter: nil,
             include: nil,

--- a/lib/jsonapi_plug/plug.ex
+++ b/lib/jsonapi_plug/plug.ex
@@ -77,6 +77,11 @@ defmodule JSONAPIPlug.Plug do
                       type: :atom,
                       required: true
                     ],
+                    includes: [
+                      doc: "A nested keyword list of allowed includes for this endpoint",
+                      type: :keyword_list,
+                      keys: [*: [type: :keyword_list]]
+                    ],
                     resource: [
                       doc: "The `JSONAPIPlug.Resource` used to parse the request.",
                       type: :atom,
@@ -96,7 +101,9 @@ defmodule JSONAPIPlug.Plug do
   require Logger
 
   alias JSONAPIPlug.{Document, Exceptions}
+
   alias JSONAPIPlug.Plug.{ContentTypeNegotiation, Params, QueryParam, ResponseContentType}
+
   alias Plug.Conn
 
   plug :config
@@ -118,7 +125,11 @@ defmodule JSONAPIPlug.Plug do
 
     %{conn | assigns: assigns}
     |> fetch_query_params()
-    |> put_private(:jsonapi_plug, %JSONAPIPlug{api: options[:api], resource: options[:resource]})
+    |> put_private(:jsonapi_plug, %JSONAPIPlug{
+      allowed_includes: options[:includes],
+      api: options[:api],
+      resource: options[:resource]
+    })
   end
 
   @impl Plug.ErrorHandler

--- a/lib/jsonapi_plug/query_parser/ecto/include.ex
+++ b/lib/jsonapi_plug/query_parser/ecto/include.ex
@@ -3,7 +3,7 @@ defmodule JSONAPIPlug.QueryParser.Ecto.Include do
   JSON:API 'include' query parameter parser implementation for Ecto
 
   Expects `include` parameter to be in the [JSON:API include](https://jsonapi.org/format/#fetching-includes)
-  format and converts them to Ecto `preload` optio to `Ecto.Repo` functions.
+  format and converts them to Ecto `preload` option to `Ecto.Repo` functions.
   """
 
   alias JSONAPIPlug.{Exceptions.InvalidQuery, QueryParser, Resource}
@@ -13,7 +13,8 @@ defmodule JSONAPIPlug.QueryParser.Ecto.Include do
   @impl QueryParser
   def parse(_jsonapi, nil), do: []
 
-  def parse(%JSONAPIPlug{resource: resource}, include) when is_binary(include) do
+  def parse(%JSONAPIPlug{allowed_includes: allowed_includes, resource: resource}, include)
+      when is_binary(include) do
     include
     |> String.split(",", trim: true)
     |> Enum.map(fn include ->
@@ -21,21 +22,28 @@ defmodule JSONAPIPlug.QueryParser.Ecto.Include do
       |> JSONAPIPlug.recase(:underscore)
       |> String.split(".", trim: true)
     end)
-    |> valid_includes(resource)
+    |> valid_includes(resource, allowed_includes)
   end
 
   def parse(%JSONAPIPlug{resource: resource}, include) do
     raise InvalidQuery, type: resource.type(), param: "include", value: include
   end
 
-  defp valid_includes(includes, resource) do
+  defp valid_includes(includes, resource, allowed_includes) do
     relationships = resource.relationships()
     valid_relationships_includes = Enum.map(relationships, &to_string(Resource.field_name(&1)))
 
     Enum.reduce(
       relationships,
       [],
-      &process_relationship_include(resource, &1, includes, &2, valid_relationships_includes)
+      &process_relationship_include(
+        resource,
+        &1,
+        includes,
+        &2,
+        valid_relationships_includes,
+        allowed_includes
+      )
     )
     |> Keyword.merge([], fn _k, a, b -> Keyword.merge(a, b) end)
   end
@@ -45,7 +53,8 @@ defmodule JSONAPIPlug.QueryParser.Ecto.Include do
          relationship,
          includes,
          valid_includes,
-         valid_relationships_includes
+         valid_relationships_includes,
+         allowed_includes
        ) do
     name = Resource.field_option(relationship, :name) || Resource.field_name(relationship)
     include_name = to_string(name)
@@ -59,6 +68,10 @@ defmodule JSONAPIPlug.QueryParser.Ecto.Include do
         )
 
       [^include_name | rest], relationship_includes ->
+        related_allowed_includes =
+          is_list(allowed_includes) &&
+            get_in(allowed_includes, [String.to_existing_atom(include_name)])
+
         case Resource.field_option(relationship, :resource) do
           nil ->
             relationship_includes
@@ -67,15 +80,31 @@ defmodule JSONAPIPlug.QueryParser.Ecto.Include do
             update_in(
               relationship_includes,
               [name],
-              &Keyword.merge(&1 || [], valid_includes([rest], related_resource))
+              &Keyword.merge(
+                &1 || [],
+                valid_includes([rest], related_resource, related_allowed_includes)
+              )
             )
         end
 
       [include_name | _] = path, relationship_includes ->
-        if include_name in valid_relationships_includes do
-          relationship_includes
-        else
-          raise InvalidQuery, type: resource.type(), param: "include", value: Enum.join(path, ".")
+        try do
+          name = String.to_existing_atom(include_name)
+
+          if include_name in valid_relationships_includes and
+               (not is_list(allowed_includes) or get_in(allowed_includes, [name])) do
+            relationship_includes
+          else
+            raise ArgumentError
+          end
+        rescue
+          ArgumentError ->
+            reraise InvalidQuery.exception(
+                      type: resource.type(),
+                      param: "include",
+                      value: Enum.join(path, ".")
+                    ),
+                    __STACKTRACE__
         end
     end)
     |> Keyword.merge(valid_includes, fn _k, a, b -> Keyword.merge(a, b) end)

--- a/test/jsonapi_plug_test.exs
+++ b/test/jsonapi_plug_test.exs
@@ -29,7 +29,7 @@ defmodule JSONAPIPlugTest do
       resource: PostResource,
       includes: [
         author: [company: [industry: []]],
-        other_user: [company: [industry: [:tags]]],
+        other_user: [company: [industry: []]],
         company: []
       ]
 

--- a/test/jsonapi_plug_test.exs
+++ b/test/jsonapi_plug_test.exs
@@ -23,7 +23,16 @@ defmodule JSONAPIPlugTest do
     use Plug.Builder
 
     plug Parsers, parsers: [:json], pass: ["text/*"], json_decoder: Jason
-    plug JSONAPIPlug.Plug, api: JSONAPIPlug.TestSupport.APIs.DefaultAPI, resource: PostResource
+
+    plug JSONAPIPlug.Plug,
+      api: JSONAPIPlug.TestSupport.APIs.DefaultAPI,
+      resource: PostResource,
+      includes: [
+        author: [company: [industry: []]],
+        other_user: [company: [industry: [:tags]]],
+        company: []
+      ]
+
     plug :passthrough
 
     defp passthrough(conn, _) do


### PR DESCRIPTION
The code is not great, but this is the minimal amount of effort possible to get the job done.

`JSONAPIPlug.Plug` now accepts an `includes` optional argument. If specified it must contain a keyword list in the format `[relationship: [subrelationship: []]` that specifies all the allowed includes for the endpoint.