### PR TITLE
Extract API from recasing function

### DIFF
--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -6,7 +6,7 @@ defmodule JSONAPIPlug.TestSupport.Resources do
   defmodule CarResource do
     @moduledoc false
 
-    use JSONAPIPlug.Resource, type: "car"
+    use JSONAPIPlug.Resource, type: "car", attributes: [:model]
   end
 
   defmodule CommentResource do
@@ -122,7 +122,7 @@ defmodule JSONAPIPlug.TestSupport.Resources do
   defmodule TagResource do
     @moduledoc false
 
-    use JSONAPIPlug.Resource, type: "tag"
+    use JSONAPIPlug.Resource, type: "tag", attributes: [:name]
   end
 
   defmodule UserResource do


### PR DESCRIPTION
This should reduce the number of calls to `API.get_config` and allow to reuse the recasing function to do underscoring elsewhere.