### PR TITLE
Refactor code

### DIFF
--- a/lib/jsonapi_plug.ex
+++ b/lib/jsonapi_plug.ex
@@ -102,7 +102,7 @@ defmodule JSONAPIPlug do
       Regex.split(~r{(?<=[a-zA-Z0-9])[-_](?=[a-zA-Z0-9])}, field)
       |> Enum.filter(&(&1 != ""))
 
-    Enum.join([String.downcase(h) | camelize_list(t)])
+    Enum.join([String.downcase(h) | Enum.map(t, &String.capitalize/1)])
   end
 
   def recase(field, :dasherize) do
@@ -115,7 +115,4 @@ defmodule JSONAPIPlug do
     |> String.replace(~r/([a-z\d])([A-Z])/, "\\1_\\2")
     |> String.downcase()
   end
-
-  defp camelize_list([]), do: []
-  defp camelize_list([h | t]), do: [String.capitalize(h) | camelize_list(t)]
 end

--- a/lib/jsonapi_plug/plug.ex
+++ b/lib/jsonapi_plug/plug.ex
@@ -168,18 +168,16 @@ defmodule JSONAPIPlug.Plug do
     send_resp(conn, 500, "Something went wrong")
   end
 
-  defp send_error(conn, code, error) do
+  defp send_error(conn, code, %Document.ErrorObject{} = error) do
+    status_code = Conn.Status.code(code)
+
     conn
     |> put_resp_content_type(JSONAPIPlug.mime_type())
     |> send_resp(
       code,
       Jason.encode!(%Document{
         errors: [
-          %Document.ErrorObject{
-            error
-            | status: to_string(Conn.Status.code(code)),
-              title: Conn.Status.reason_phrase(Conn.Status.code(code))
-          }
+          %{error | status: to_string(status_code), title: Conn.Status.reason_phrase(status_code)}
         ]
       })
     )

--- a/lib/jsonapi_plug/plug/params.ex
+++ b/lib/jsonapi_plug/plug/params.ex
@@ -29,6 +29,6 @@ defmodule JSONAPIPlug.Plug.Params do
       |> Document.deserialize()
       |> Normalizer.denormalize(jsonapi_plug.resource, conn)
 
-    Conn.put_private(conn, :jsonapi_plug, %JSONAPIPlug{jsonapi_plug | params: body_params})
+    Conn.put_private(conn, :jsonapi_plug, %{jsonapi_plug | params: body_params})
   end
 end


### PR DESCRIPTION
This is only a code refactoring. 

The main change is that i changed the pattern: 
```
%Stuff{} |> set_a(data) |> set_b(data) |> set_c(data)
```
Into
```
%Stuff{a: create_a(data), b: create_b(data)}
```
I did this because `set_a` function is more complex than `create_a` and it is explicit that to create the `a` value I use only `data`.