### PR TITLE
Support `JSON:API` 1.1 lid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This is the result of a big refactoring, cleaning up internals and providing a m
 stable foundation for the library moving forward. This means there are a number of
 breaking changes that require changes to applications using `JSONAPIPlug`.
 
-See the upgrade guide in the docs for detailed upgrade instructions from 1.0.
+See the [upgrade guide][upgrade] in the docs for detailed upgrade instructions from 1.0.
 
 - `JSONAPIPlug.Resource` is now a protocol instead of a behaviour.
   Using structs as resource data is now mandatory.
@@ -77,3 +77,5 @@ What `jsonapi_plug` has to offer to users of Phoenix/Plug for building `JSON:API
 - A declarative resource system allowing users to control rendering, rename fields between `JSON:API` payloads and internal data, customize (de)serialization of fields values and more without writing additional business logic code.
 
 Contributors: @lucacorti
+
+[upgrade]: https://hexdocs.pm/jsonapi_plug/upgrading.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@ See the upgrade guide in the docs for detailed upgrade instructions from 1.0.
   callbacks has been replaces by the `JSONAPIPlug.Resource.Links` and
   `JSONAPIPlug.Resource.Meta` protocols.
 - Removed `links` option to `JSONAPIPlug.API`. Resource links are always generated.
-- Moved the Phoenix render function to a component module in the library, is can be
-  added to the phoenix `MyAppWeb` module and imported in the phoenix `_json.ex`
+- Moved the Phoenix render function to a component module in the library, thiis can
+  be added to the phoenix `MyAppWeb` module and imported in the phoenix `_json.ex`
   module via `use MyAppWeb, :jsonapi` as per phoenix conventions.
+- Enforce `client_generated_ids` option. This prevents sending ids in resources and
+  included resources when `client_generated_ids` is turned off. If you were sending
+  ids to support resource creation with included atomically, this is now supported
+  by sending `JSON:API 1.1` `lid` in relationships and included resources. This
+  is supported even though the reported jsonapi vesion is still `1.0` becasuse the
+  library still doesn't have full `JSON:API 1.1` support. Only `lid` is supported.
 
 Contributors: @lucacorti
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ Server library to build [JSON:API](http://jsonapi.org) compliant REST APIs.
 
 ## JSON:API Support
 
-This library currently implements version `1.0` of the [JSON:API](https://jsonapi.org) specification.
+This library currently implements version `1.0` of the [JSON:API][json:api] specification.
+However, to support resource creation alongside included resources, `JSON:API 1.1` `lid` is supported.
 
 ## Documentation
 
-- [Full docs here](https://hexdocs.pm/jsonapi_plug)
-- [JSON API Specification (v1.0)](https://jsonapi.org/format/1.0/)
+- Full documentation can be found on [hexdocs.pm][jsonapi_plug-hexdocs]
+
+For the `JSON:API` specification documentation as well as other client and server implementations:
+
+- [JSON:API][json:api]
+- [JSON:API Specification (v1.0)][json:api-1.0]
+- [JSON:API Specification (v1.1)][json:api-1.1]
 
 ## Quickstart
 
@@ -20,10 +26,17 @@ Add the following line to your `mix.deps` file with the desired version to insta
 ```elixir
 defp deps do [
   ...
-  {:jsonapi_plug, "~> 1.0"}
+  {:jsonapi_plug, "~> 2.0"}
   ...
 ]
 ```
+
+### Upgrading
+
+Upgrading the library should be safe for minor and patch vesion upgrades, it's still a good practice
+to check the [changelog][changelog] for more information on the release content. For major version
+upgrades, breaking changes should be expected, and the [upgrade guide][upgrade] contains instructions
+on upgrading between major releases of the library.
 
 ### Configuration
 
@@ -175,7 +188,15 @@ Render returns a `JSONAPI.Document`, that is serializable to JSON via `Jason`.
 
 ## Contributing
 
-- This project was born as a fork of the [jsonapi](https://github.com/beam-community/jsonapi)
+- This project was born as a fork of the [jsonapi][jsonapi-fork]
 library but has since been completely rewritten and is now a completely different project.
 - PRs for new features, bug fixes, documentation and tests are welcome
 - If you are proposing a large feature or change, please open an issue for discussion
+
+[changelog]: https://hexdocs.pm/jsonapi_plug/changelog.html
+[json:api-1.0]: https://jsonapi.org/format/1.0/
+[json:api-1.1]: https://jsonapi.org/format/1.1/
+[json:api]: https://jsonapi.org
+[jsonapi-fork]: https://github.com/beam-community/jsonapi
+[jsonapi_plug-hexdocs]: https://hexdocs.pm/jsonapi_plug
+[upgrade]: https://hexdocs.pm/jsonapi_plug/upgrading.html

--- a/guides/upgrading.md
+++ b/guides/upgrading.md
@@ -1,6 +1,6 @@
 # Upgrading
 
-Upgrade instructions between major versions of `JSONAPIPlug`.
+Instructions to upgrade between major versions of `JSONAPIPlug`.
 
 ## Upgrading from 1.x to 2.0
 

--- a/guides/upgrading.md
+++ b/guides/upgrading.md
@@ -23,3 +23,8 @@ Upgrade instructions between major versions of `JSONAPIPlug`.
     `JSONAPIPlug.Resource.Meta` protocol for your resource to add per-resource `JSON:API` meta.
   6. If you use phonenix, either call `JSONAPIPlug.render/5` in your controllers or add `use MyAppWeb, :json_api`
      to your `_json.ex` modules and call `render/3`. See the README for complete instructions.
+  7. If you are sending resource `ids` in `included` for resource create requests, this is now forbidden unless
+     the `client_generated_ids` option is configured on your `JSONAPIPlug.API`. You can however use `JSON:API 1.1`
+     `lid` in relationships and included resources if you whish to create resources with included resources atomically.
+     Please note that this works even though the reported `JSON:API` version is still `1.0`, because the library still
+     does not support the full `JSON:API 1.1` specification yet, only `lid` is supported for now.

--- a/lib/jsonapi_plug/document/resource_identifier_object.ex
+++ b/lib/jsonapi_plug/document/resource_identifier_object.ex
@@ -9,27 +9,19 @@ defmodule JSONAPIPlug.Document.ResourceIdentifierObject do
 
   @type t :: %__MODULE__{
           id: ResourceObject.id(),
+          lid: ResourceObject.id(),
           type: ResourceObject.type(),
           meta: Document.meta() | nil
         }
-  defstruct [:id, :type, :meta]
+  defstruct [:id, :lid, :meta, :type]
 
   @spec deserialize(Document.payload()) :: t() | no_return()
   def deserialize(data) do
     %__MODULE__{}
     |> deserialize_id(data)
-    |> deserialize_type(data)
+    |> deserialize_lid(data)
     |> deserialize_meta(data)
-  end
-
-  defp deserialize_type(resource_identifier_object, %{"type" => type})
-       when is_binary(type) and byte_size(type) > 0,
-       do: %__MODULE__{resource_identifier_object | type: type}
-
-  defp deserialize_type(_resource_identifier_object, type) do
-    raise InvalidDocument,
-      message: "Resource Identifier object type (#{type}) is invalid",
-      reference: "https://jsonapi.org/format/#document-resource-objects"
+    |> deserialize_type(data)
   end
 
   defp deserialize_id(resource_identifier_object, %{"id" => id})
@@ -38,6 +30,12 @@ defmodule JSONAPIPlug.Document.ResourceIdentifierObject do
 
   defp deserialize_id(resource_identifier_object, _data),
     do: resource_identifier_object
+
+  defp deserialize_lid(resource_object, %{"lid" => lid})
+       when is_binary(lid) and byte_size(lid) > 0,
+       do: %__MODULE__{resource_object | lid: lid}
+
+  defp deserialize_lid(resource_object, _data), do: resource_object
 
   defp deserialize_meta(resource_identifier_object, %{"meta" => meta})
        when is_map(meta),
@@ -51,4 +49,14 @@ defmodule JSONAPIPlug.Document.ResourceIdentifierObject do
 
   defp deserialize_meta(resource_identifier_object, _payload),
     do: resource_identifier_object
+
+  defp deserialize_type(resource_identifier_object, %{"type" => type})
+       when is_binary(type) and byte_size(type) > 0,
+       do: %__MODULE__{resource_identifier_object | type: type}
+
+  defp deserialize_type(_resource_identifier_object, type) do
+    raise InvalidDocument,
+      message: "Resource Identifier object type (#{type}) is invalid",
+      reference: "https://jsonapi.org/format/#document-resource-objects"
+  end
 end

--- a/lib/jsonapi_plug/document/resource_object.ex
+++ b/lib/jsonapi_plug/document/resource_object.ex
@@ -62,7 +62,7 @@ defmodule JSONAPIPlug.Document.ResourceObject do
 
   defp deserialize_type(_resource_object, %{"type" => type}) do
     raise InvalidDocument,
-      message: "Resource object type (#{type}) is invalid",
+      message: "Resource object type '#{type}' is invalid",
       reference: "https://jsonapi.org/format/#document-resource-objects"
   end
 

--- a/lib/jsonapi_plug/normalizer.ex
+++ b/lib/jsonapi_plug/normalizer.ex
@@ -98,26 +98,26 @@ defmodule JSONAPIPlug.Normalizer do
          resource,
          %Conn{private: %{jsonapi_plug: %JSONAPIPlug{} = jsonapi_plug}}
        ) do
-    if jsonapi_plug.config[:client_generated_ids] do
-      if is_nil(resource_object.id) do
+    case {jsonapi_plug.config[:client_generated_ids], resource_object.id} do
+      {true, nil} ->
         raise InvalidDocument,
           message: "Resource ID not received in request and API requires Client-Generated IDs",
           reference: "https://jsonapi.org/format/1.0/#crud-creating-client-ids"
-      else
+
+      {true, id} ->
         jsonapi_plug.config[:normalizer].denormalize_attribute(
           params,
           Resource.id_attribute(resource),
-          resource_object.id
+          id
         )
-      end
-    else
-      if is_nil(resource_object.id) do
+
+      {false, nil} ->
         params
-      else
+
+      {false, _id} ->
         raise InvalidDocument,
           message: "Resource ID received in request and API forbids Client-Generated IDs",
           reference: "https://jsonapi.org/format/1.0/#crud-creating-client-ids"
-      end
     end
   end
 

--- a/lib/jsonapi_plug/normalizer.ex
+++ b/lib/jsonapi_plug/normalizer.ex
@@ -111,7 +111,13 @@ defmodule JSONAPIPlug.Normalizer do
         )
       end
     else
-      params
+      if is_nil(resource_object.id) do
+        params
+      else
+        raise InvalidDocument,
+          message: "Resource ID received in request and API forbids Client-Generated IDs",
+          reference: "https://jsonapi.org/format/1.0/#crud-creating-client-ids"
+      end
     end
   end
 

--- a/lib/jsonapi_plug/normalizer.ex
+++ b/lib/jsonapi_plug/normalizer.ex
@@ -250,7 +250,7 @@ defmodule JSONAPIPlug.Normalizer do
         id
       ),
       fn
-        %ResourceObject{id: id, lid: lid} when is_nil(id) and is_nil(lid) ->
+        %ResourceObject{id: nil, lid: nil} ->
           nil
 
         %ResourceObject{type: ^type} = resource_object ->
@@ -259,11 +259,15 @@ defmodule JSONAPIPlug.Normalizer do
             jsonapi_plug.config[:client_generated_ids],
             resource_object
           } do
-            {method, c_g_ids, %ResourceObject{id: ^id}}
-            when (method == "PATCH" or c_g_ids) and not is_nil(id) ->
+            {method, client_generated_ids, %ResourceObject{id: ^id}}
+            when (method == "PATCH" or client_generated_ids) and not is_nil(id) ->
               denormalize_resource(document, resource_object, related_resource, conn)
 
-            {method, _c_g_ids, %ResourceObject{lid: ^lid}}
+            {method, _client_generated_ids, %ResourceObject{id: ^id}}
+            when method != "PATCH" and not is_nil(id) ->
+              denormalize_resource(document, resource_object, related_resource, conn)
+
+            {method, _client_generated_ids, %ResourceObject{lid: ^lid}}
             when method != "PATCH" and not is_nil(lid) ->
               denormalize_resource(document, resource_object, related_resource, conn)
 

--- a/lib/jsonapi_plug/normalizer.ex
+++ b/lib/jsonapi_plug/normalizer.ex
@@ -181,10 +181,14 @@ defmodule JSONAPIPlug.Normalizer do
         {_many?, nil} ->
           params
 
-        {true, %RelationshipObject{data: data} = relationship_object} when is_list(data) ->
+        {_many?, %RelationshipObject{data: nil} = _relationship_object} ->
+          params
+
+        {true, %RelationshipObject{data: resource_identifier_object} = relationship_object}
+        when is_list(resource_identifier_object) ->
           value =
             Enum.map(
-              data,
+              resource_identifier_object,
               &denormalize_relationship(document, &1, related_resource, conn)
             )
 
@@ -204,9 +208,6 @@ defmodule JSONAPIPlug.Normalizer do
           raise InvalidDocument,
             message: "List of resources for one-to-one relationship during normalization",
             reference: nil
-
-        {false, %RelationshipObject{data: nil} = _relationship_object} ->
-          params
 
         {false, %RelationshipObject{data: resource_identifier_object} = relationship_object} ->
           value =

--- a/lib/jsonapi_plug/normalizer/ecto.ex
+++ b/lib/jsonapi_plug/normalizer/ecto.ex
@@ -39,7 +39,7 @@ defmodule JSONAPIPlug.Normalizer.Ecto do
       ) do
     params = Map.put(params, to_string(relationship), value)
 
-    if data.id do
+    if data do
       Map.put(params, "#{relationship}_id", data.id)
     else
       params

--- a/lib/jsonapi_plug/normalizer/ecto.ex
+++ b/lib/jsonapi_plug/normalizer/ecto.ex
@@ -37,8 +37,12 @@ defmodule JSONAPIPlug.Normalizer.Ecto do
         relationship,
         value
       ) do
-    params
-    |> Map.put(to_string(relationship), value)
-    |> Map.put("#{relationship}_id", if(data, do: data.id))
+    params = Map.put(params, to_string(relationship), value)
+
+    if data.id do
+      Map.put(params, "#{relationship}_id", data.id)
+    else
+      params
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,11 @@ defmodule JSONAPIPlug.Mixfile do
   defp docs do
     [
       main: "readme",
-      extras: ["README.md", "guides/upgrading.md"],
+      extras: [
+        "README.md",
+        "guides/upgrading.md": [title: "Upgrading between major versions"],
+        "CHANGELOG.md": [title: "Changelog"]
+      ],
       groups_for_modules: [
         Document: [~r/JSONAPIPlug\.Document.*/],
         Resource: [~r/JSONAPIPlug\.Resource.*/],


### PR DESCRIPTION
Add support for `JSON:API` 1.1 `lid` in resource object:

- Deserialize `lid` in `JSON:API` document.
- Use `lid` to establish relationship with included resources in requests.
- Enforce `id` presence/absence when denormalizing resources.

Fixes #5 