### PR TITLE
Cleanup code

### DIFF
--- a/lib/jsonapi_plug/document/error_object.ex
+++ b/lib/jsonapi_plug/document/error_object.ex
@@ -28,20 +28,16 @@ defmodule JSONAPIPlug.Document.ErrorObject do
 
   @spec deserialize(Document.payload()) :: t() | no_return()
   def deserialize(data) do
-    error = %__MODULE__{}
-
-    attrs =
-      error
-      |> Map.from_struct()
-      |> Map.keys()
-      |> Enum.reduce([], fn key, attrs ->
-        case Map.fetch(data, Atom.to_string(key)) do
-          {:ok, value} -> Map.put(attrs, key, value)
-          :error -> attrs
-        end
-      end)
-
-    struct(%__MODULE__{}, attrs)
+    %__MODULE__{
+      code: data["code"],
+      detail: data["detail"],
+      id: data["id"],
+      links: data["links"],
+      meta: data["meta"],
+      source: data["source"],
+      status: data["status"],
+      title: data["title"]
+    }
   end
 
   @spec serialize(t()) :: t()

--- a/lib/jsonapi_plug/document/jsonapi_object.ex
+++ b/lib/jsonapi_plug/document/jsonapi_object.ex
@@ -12,33 +12,26 @@ defmodule JSONAPIPlug.Document.JSONAPIObject do
 
   @spec deserialize(Document.payload()) :: t() | no_return()
   def deserialize(data) do
-    %__MODULE__{}
-    |> deserialize_meta(data)
-    |> deserialize_version(data)
+    %__MODULE__{meta: deserialize_meta(data), version: deserialize_version(data)}
   end
 
-  defp deserialize_meta(jsonapi_object, %{"meta" => meta}) when is_map(meta),
-    do: %__MODULE__{jsonapi_object | meta: meta}
+  defp deserialize_meta(%{"meta" => meta}) when is_map(meta), do: meta
 
-  defp deserialize_meta(_jsonapi_object, %{"meta" => _meta}) do
+  defp deserialize_meta(%{"meta" => _meta}) do
     raise InvalidDocument,
       message: "JSON:API object 'meta' must be an object",
       reference: "https://jsonapi.org/format/#document-jsonapi-object"
   end
 
-  defp deserialize_meta(jsonapi_object, _data), do: jsonapi_object
+  defp deserialize_meta(_data), do: nil
+  defp deserialize_version(%{"version" => "1.0"}), do: :"1.0"
+  defp deserialize_version(%{"version" => "1.1"}), do: :"1.1"
 
-  defp deserialize_version(jsonapi_object, %{"version" => "1.0"}),
-    do: %__MODULE__{jsonapi_object | version: :"1.0"}
-
-  defp deserialize_version(jsonapi_object, %{"version" => "1.1"}),
-    do: %__MODULE__{jsonapi_object | version: :"1.1"}
-
-  defp deserialize_version(_jsonapi_object, %{"version" => version}) do
+  defp deserialize_version(%{"version" => version}) do
     raise InvalidDocument,
       message: "JSON:API Object has invalid version (#{version})",
       reference: "https://jsonapi.org/format/#document-jsonapi-object"
   end
 
-  defp deserialize_version(jsonapi_object, _data), do: jsonapi_object
+  defp deserialize_version(_data), do: nil
 end

--- a/lib/jsonapi_plug/document/jsonapi_object.ex
+++ b/lib/jsonapi_plug/document/jsonapi_object.ex
@@ -5,9 +5,9 @@ defmodule JSONAPIPlug.Document.JSONAPIObject do
 
   alias JSONAPIPlug.{Document, Exceptions.InvalidDocument}
 
-  @type version :: :"1.0"
+  @type version :: :"1.0" | :"1.1"
 
-  @type t :: %__MODULE__{meta: Document.meta() | nil, version: version()}
+  @type t :: %__MODULE__{meta: Document.meta() | nil, version: version() | nil}
   defstruct meta: nil, version: nil
 
   @spec deserialize(Document.payload()) :: t() | no_return()

--- a/lib/jsonapi_plug/document/link_object.ex
+++ b/lib/jsonapi_plug/document/link_object.ex
@@ -14,21 +14,14 @@ defmodule JSONAPIPlug.Document.LinkObject do
   def deserialize(data) when is_binary(data), do: data
 
   def deserialize(data) when is_map(data) do
-    %__MODULE__{}
-    |> deserialize_href(data)
-    |> deserialize_meta(data)
+    %__MODULE__{href: deserialize_href(data), meta: deserialize_meta(data)}
   end
 
-  defp deserialize_href(%__MODULE__{} = link_object, %{"href" => href})
-       when is_binary(href) and byte_size(href) > 0,
-       do: %__MODULE__{link_object | href: href}
+  defp deserialize_href(%{"href" => href}) when is_binary(href) and byte_size(href) > 0, do: href
+  defp deserialize_href(_data), do: nil
 
-  defp deserialize_href(link_object, _data), do: link_object
-
-  defp deserialize_meta(link_object, %{"meta" => meta}) when is_map(meta),
-    do: %__MODULE__{link_object | meta: meta}
-
-  defp deserialize_meta(link_object, _data), do: link_object
+  defp deserialize_meta(%{"meta" => meta}) when is_map(meta), do: meta
+  defp deserialize_meta(_data), do: nil
 
   @spec serialize(t()) :: t()
   def serialize(link_object), do: link_object

--- a/lib/jsonapi_plug/document/link_object.ex
+++ b/lib/jsonapi_plug/document/link_object.ex
@@ -7,7 +7,7 @@ defmodule JSONAPIPlug.Document.LinkObject do
 
   alias JSONAPIPlug.Document
 
-  @type t :: %__MODULE__{href: String.t(), meta: Document.meta() | nil} | String.t()
+  @type t :: %__MODULE__{href: String.t() | nil, meta: Document.meta() | nil} | String.t()
   defstruct [:href, :meta]
 
   @spec deserialize(Document.payload()) :: t() | no_return()

--- a/lib/jsonapi_plug/document/relationship_object.ex
+++ b/lib/jsonapi_plug/document/relationship_object.ex
@@ -24,47 +24,39 @@ defmodule JSONAPIPlug.Document.RelationshipObject do
 
   @spec deserialize(Document.payload()) :: t() | no_return()
   def deserialize(data) do
-    %__MODULE__{}
-    |> deserialize_data(data)
-    |> deserialize_links(data)
-    |> deserialize_meta(data)
+    %__MODULE__{
+      data: deserialize_data(data),
+      links: deserialize_links(data),
+      meta: deserialize_meta(data)
+    }
   end
 
-  defp deserialize_data(relationship_object, %{"data" => resource_identifier})
+  defp deserialize_data(%{"data" => resource_identifier})
        when is_map(resource_identifier),
-       do: %__MODULE__{
-         relationship_object
-         | data: ResourceIdentifierObject.deserialize(resource_identifier)
-       }
+       do: ResourceIdentifierObject.deserialize(resource_identifier)
 
-  defp deserialize_data(relationship_object, %{"data" => resource_identifiers})
+  defp deserialize_data(%{"data" => resource_identifiers})
        when is_list(resource_identifiers),
-       do: %__MODULE__{
-         relationship_object
-         | data: Enum.map(resource_identifiers, &ResourceIdentifierObject.deserialize/1)
-       }
+       do: Enum.map(resource_identifiers, &ResourceIdentifierObject.deserialize/1)
 
-  defp deserialize_data(relationship_object, _data), do: relationship_object
+  defp deserialize_data(_data), do: nil
 
-  defp deserialize_links(relationship_object, %{"links" => links}),
-    do: %__MODULE__{
-      relationship_object
-      | links:
-          Enum.into(links, %{}, fn {name, link} ->
-            {name, LinkObject.deserialize(link)}
-          end)
-    }
+  defp deserialize_links(%{"links" => links}),
+    do:
+      Enum.into(links, %{}, fn {name, link} ->
+        {name, LinkObject.deserialize(link)}
+      end)
 
-  defp deserialize_links(relationship_object, _data), do: relationship_object
+  defp deserialize_links(_data), do: nil
 
-  defp deserialize_meta(relationship_object, %{"meta" => meta}) when is_map(meta),
-    do: %__MODULE__{relationship_object | meta: meta}
+  defp deserialize_meta(%{"meta" => meta}) when is_map(meta),
+    do: meta
 
-  defp deserialize_meta(_relationship_object, %{"meta" => _meta}) do
+  defp deserialize_meta(%{"meta" => _meta}) do
     raise InvalidDocument,
       message: "Relationship object 'meta' must be an object",
       reference: "https://jsonapi.org/format/#document-resource-object-relationships"
   end
 
-  defp deserialize_meta(relationship_object, _data), do: relationship_object
+  defp deserialize_meta(_data), do: nil
 end

--- a/lib/jsonapi_plug/document/resource_identifier_object.ex
+++ b/lib/jsonapi_plug/document/resource_identifier_object.ex
@@ -17,44 +17,33 @@ defmodule JSONAPIPlug.Document.ResourceIdentifierObject do
 
   @spec deserialize(Document.payload()) :: t() | no_return()
   def deserialize(data) do
-    %__MODULE__{}
-    |> deserialize_id(data)
-    |> deserialize_lid(data)
-    |> deserialize_meta(data)
-    |> deserialize_type(data)
+    %__MODULE__{
+      id: deserialize_id(data),
+      lid: deserialize_lid(data),
+      meta: deserialize_meta(data),
+      type: deserialize_type(data)
+    }
   end
 
-  defp deserialize_id(resource_identifier_object, %{"id" => id})
-       when is_binary(id) and byte_size(id) > 0,
-       do: %__MODULE__{resource_identifier_object | id: id}
+  defp deserialize_id(%{"id" => id}) when is_binary(id) and byte_size(id) > 0, do: id
+  defp deserialize_id(_data), do: nil
 
-  defp deserialize_id(resource_identifier_object, _data),
-    do: resource_identifier_object
+  defp deserialize_lid(%{"lid" => lid}) when is_binary(lid) and byte_size(lid) > 0, do: lid
+  defp deserialize_lid(_data), do: nil
 
-  defp deserialize_lid(resource_object, %{"lid" => lid})
-       when is_binary(lid) and byte_size(lid) > 0,
-       do: %__MODULE__{resource_object | lid: lid}
+  defp deserialize_meta(%{"meta" => meta}) when is_map(meta), do: meta
 
-  defp deserialize_lid(resource_object, _data), do: resource_object
-
-  defp deserialize_meta(resource_identifier_object, %{"meta" => meta})
-       when is_map(meta),
-       do: %__MODULE__{resource_identifier_object | meta: meta}
-
-  defp deserialize_meta(_resource_identifier_object, %{"meta" => _meta}) do
+  defp deserialize_meta(%{"meta" => _meta}) do
     raise InvalidDocument,
       message: "Resource Identifier object 'meta' must be an object",
       reference: "https://jsonapi.org/format/#document-resource-identifier-objects"
   end
 
-  defp deserialize_meta(resource_identifier_object, _payload),
-    do: resource_identifier_object
+  defp deserialize_meta(_payload), do: nil
 
-  defp deserialize_type(resource_identifier_object, %{"type" => type})
-       when is_binary(type) and byte_size(type) > 0,
-       do: %__MODULE__{resource_identifier_object | type: type}
+  defp deserialize_type(%{"type" => type}) when is_binary(type) and byte_size(type) > 0, do: type
 
-  defp deserialize_type(_resource_identifier_object, type) do
+  defp deserialize_type(type) do
     raise InvalidDocument,
       message: "Resource Identifier object type (#{type}) is invalid",
       reference: "https://jsonapi.org/format/#document-resource-objects"

--- a/lib/jsonapi_plug/document/resource_identifier_object.ex
+++ b/lib/jsonapi_plug/document/resource_identifier_object.ex
@@ -8,8 +8,8 @@ defmodule JSONAPIPlug.Document.ResourceIdentifierObject do
   alias JSONAPIPlug.{Document, Document.ResourceObject, Exceptions.InvalidDocument}
 
   @type t :: %__MODULE__{
-          id: ResourceObject.id(),
-          lid: ResourceObject.id(),
+          id: ResourceObject.id() | nil,
+          lid: ResourceObject.id() | nil,
           type: ResourceObject.type(),
           meta: Document.meta() | nil
         }

--- a/lib/jsonapi_plug/document/resource_object.ex
+++ b/lib/jsonapi_plug/document/resource_object.ex
@@ -34,98 +34,81 @@ defmodule JSONAPIPlug.Document.ResourceObject do
 
   @spec deserialize(Document.payload()) :: t() | no_return()
   def deserialize(data) do
-    %__MODULE__{}
-    |> deserialize_id(data)
-    |> deserialize_lid(data)
-    |> deserialize_type(data)
-    |> deserialize_attributes(data)
-    |> deserialize_links(data)
-    |> deserialize_relationships(data)
-    |> deserialize_meta(data)
+    %__MODULE__{
+      id: deserialize_id(data),
+      lid: deserialize_lid(data),
+      type: deserialize_type(data),
+      attributes: deserialize_attributes(data),
+      links: deserialize_links(data),
+      relationships: deserialize_relationships(data),
+      meta: deserialize_meta(data)
+    }
   end
 
-  defp deserialize_id(resource_object, %{"id" => id})
-       when is_binary(id) and byte_size(id) > 0,
-       do: %__MODULE__{resource_object | id: id}
+  defp deserialize_id(%{"id" => id}) when is_binary(id) and byte_size(id) > 0, do: id
+  defp deserialize_id(_data), do: nil
 
-  defp deserialize_id(resource_object, _data), do: resource_object
+  defp deserialize_lid(%{"lid" => lid}) when is_binary(lid) and byte_size(lid) > 0, do: lid
+  defp deserialize_lid(_data), do: nil
 
-  defp deserialize_lid(resource_object, %{"lid" => lid})
-       when is_binary(lid) and byte_size(lid) > 0,
-       do: %__MODULE__{resource_object | lid: lid}
+  defp deserialize_type(%{"type" => type}) when is_binary(type) and byte_size(type) > 0, do: type
 
-  defp deserialize_lid(resource_object, _data), do: resource_object
-
-  defp deserialize_type(resource_object, %{"type" => type})
-       when is_binary(type) and byte_size(type) > 0,
-       do: %__MODULE__{resource_object | type: type}
-
-  defp deserialize_type(_resource_object, %{"type" => type}) do
+  defp deserialize_type(%{"type" => type}) do
     raise InvalidDocument,
       message: "Resource object type '#{type}' is invalid",
       reference: "https://jsonapi.org/format/#document-resource-objects"
   end
 
-  defp deserialize_attributes(_resource_object, %{"attributes" => %{"id" => _id}}) do
+  defp deserialize_attributes(%{"attributes" => %{"id" => _id}}) do
     raise InvalidDocument,
       message: "Resource object cannot have an attribute named 'id'",
       reference: "https://jsonapi.org/format/#document-resource-objects"
   end
 
-  defp deserialize_attributes(_resource_object, %{"attributes" => %{"type" => _type}}) do
+  defp deserialize_attributes(%{"attributes" => %{"type" => _type}}) do
     raise InvalidDocument,
       message: "Resource object cannot have an attribute named 'type'",
       reference: "https://jsonapi.org/format/#document-resource-objects"
   end
 
-  defp deserialize_attributes(resource_object, %{"attributes" => attributes})
+  defp deserialize_attributes(%{"attributes" => attributes})
        when is_map(attributes),
-       do: %__MODULE__{resource_object | attributes: attributes}
+       do: attributes
 
-  defp deserialize_attributes(resource_object, _data), do: resource_object
+  defp deserialize_attributes(_data), do: %{}
 
-  defp deserialize_links(resource_object, %{"links" => links}),
-    do: %__MODULE__{
-      resource_object
-      | links:
-          Enum.into(links, %{}, fn {name, link} ->
-            {name, LinkObject.deserialize(link)}
-          end)
-    }
+  defp deserialize_links(%{"links" => links}),
+    do:
+      Enum.into(links, %{}, fn {name, link} ->
+        {name, LinkObject.deserialize(link)}
+      end)
 
-  defp deserialize_links(resource_object, _data), do: resource_object
+  defp deserialize_links(_data), do: nil
 
-  defp deserialize_relationships(_resource_object, %{"relationships" => %{"id" => _id}}) do
+  defp deserialize_relationships(%{"relationships" => %{"id" => _id}}) do
     raise InvalidDocument,
       message: "Resource object cannot have a relationship named 'id'",
       reference: "https://jsonapi.org/format/#document-resource-objects"
   end
 
-  defp deserialize_relationships(_resource_object, %{"relationships" => %{"type" => _type}}) do
+  defp deserialize_relationships(%{"relationships" => %{"type" => _type}}) do
     raise InvalidDocument,
       message: "Resource object cannot have a relationship named 'type'",
       reference: "https://jsonapi.org/format/#document-resource-objects"
   end
 
-  defp deserialize_relationships(
-         resource_object,
-         %{"relationships" => relationships}
-       )
+  defp deserialize_relationships(%{"relationships" => relationships})
        when is_map(relationships) do
-    %__MODULE__{
-      resource_object
-      | relationships:
-          Enum.into(relationships, %{}, fn
-            {name, data} when is_list(data) ->
-              {name, Enum.map(data, &RelationshipObject.deserialize/1)}
+    Enum.into(relationships, %{}, fn
+      {name, data} when is_list(data) ->
+        {name, Enum.map(data, &RelationshipObject.deserialize/1)}
 
-            {name, data} ->
-              {name, RelationshipObject.deserialize(data)}
-          end)
-    }
+      {name, data} ->
+        {name, RelationshipObject.deserialize(data)}
+    end)
   end
 
-  defp deserialize_relationships(_resource_object, %{
+  defp deserialize_relationships(%{
          "relationships" => _relationships
        }) do
     raise InvalidDocument,
@@ -133,18 +116,17 @@ defmodule JSONAPIPlug.Document.ResourceObject do
       reference: "https://jsonapi.org/format/#document-resource-object-relationships"
   end
 
-  defp deserialize_relationships(relationships, _data), do: relationships
+  defp deserialize_relationships(_data), do: %{}
 
-  defp deserialize_meta(resource_object, %{"meta" => meta}) when is_map(meta),
-    do: %__MODULE__{resource_object | meta: meta}
+  defp deserialize_meta(%{"meta" => meta}) when is_map(meta), do: meta
 
-  defp deserialize_meta(_resource_object, %{"meta" => _meta}) do
+  defp deserialize_meta(%{"meta" => _meta}) do
     raise InvalidDocument,
       message: "Resource object 'meta' must be an object",
       reference: "https://jsonapi.org/format/#document-resource-objects"
   end
 
-  defp deserialize_meta(resource_object, _data), do: resource_object
+  defp deserialize_meta(_data), do: nil
 
   @spec serialize(t()) :: t()
   def serialize(resource_object), do: resource_object

--- a/lib/jsonapi_plug/document/resource_object.ex
+++ b/lib/jsonapi_plug/document/resource_object.ex
@@ -16,13 +16,13 @@ defmodule JSONAPIPlug.Document.ResourceObject do
   @type type :: String.t()
 
   @type t :: %__MODULE__{
-          id: id(),
-          lid: id(),
+          id: id() | nil,
+          lid: id() | nil,
           type: type(),
-          attributes: %{String.t() => Document.value()} | nil,
+          attributes: %{String.t() => Document.value()},
           links: Document.links() | nil,
           meta: Document.meta() | nil,
-          relationships: %{String.t() => [RelationshipObject.t()]} | nil
+          relationships: %{String.t() => [RelationshipObject.t()]}
         }
   defstruct id: nil,
             lid: nil,


### PR DESCRIPTION
Cleanup document deserialization and fix some typespecs that were incorrect

The main change is from a pattern like 
```
%__MODULE__{} |> create_field1(data) |> create_field2(data)
```
to
```
%__MODULE__{ 
field1: create_field1(data),
field2: create_field1(data)
}
```

I did this because the `create_field` functions are smaller and easyer to read and because it is explicit that `field2` creation does not depends on `field1`
