### PR TITLE
Enable denormalize_resource using 'lid' for PATCH method

### DIFF
--- a/lib/jsonapi_plug/normalizer.ex
+++ b/lib/jsonapi_plug/normalizer.ex
@@ -274,23 +274,15 @@ defmodule JSONAPIPlug.Normalizer do
          %ResourceIdentifierObject{id: id, lid: lid, type: type},
          resource_object,
          related_resource,
-         %Conn{private: %{jsonapi_plug: %JSONAPIPlug{} = jsonapi_plug}} = conn
+         %Conn{private: %{jsonapi_plug: %JSONAPIPlug{}}} = conn
        ) do
-    case {
-      conn.method,
-      jsonapi_plug.config[:client_generated_ids],
-      resource_object
-    } do
-      {method, client_generated_ids, %ResourceObject{id: ^id, type: ^type}}
-      when (method == "PATCH" or client_generated_ids) and not is_nil(id) ->
+    case resource_object do
+      %ResourceObject{id: ^id, type: ^type}
+      when not is_nil(id) ->
         denormalize_resource(document, resource_object, related_resource, conn)
 
-      {method, _client_generated_ids, %ResourceObject{id: ^id, type: ^type}}
-      when method != "PATCH" and not is_nil(id) ->
-        denormalize_resource(document, resource_object, related_resource, conn)
-
-      {method, _client_generated_ids, %ResourceObject{lid: ^lid, type: ^type}}
-      when method != "PATCH" and not is_nil(lid) ->
+      %ResourceObject{lid: ^lid, type: ^type}
+      when not is_nil(lid) ->
         denormalize_resource(document, resource_object, related_resource, conn)
 
       _other ->


### PR DESCRIPTION
Makes it possible to use `lid` even when making a PATCH request.  

The condition is now much simpler because removing the `method` check automatically makes the `client_generated_ids` check unnecessary. Regardless of whether it's `true` or `false`, the code will always execute `denormalize_resource`.  

Additionally, there's no need to check `client_generated_ids` at this stage, as all necessary validations are performed later in [denormalize_id](https://github.com/davidgarra92/jsonapi_plug/blob/e0cba727f98e9a02adce717c715247e937adee21/lib/jsonapi_plug/normalizer.ex#L108).